### PR TITLE
Python 3 compatibility

### DIFF
--- a/__main__.py
+++ b/__main__.py
@@ -19,7 +19,7 @@ try:
         messages.append(muni.get_predictions())
         text = '<FI>'.join(messages)
         display_text = "<ID01><PA>  <FD>{}{}  \r\n".format(text, datetime.now().strftime('%H:%M'))
-        print display_text
+        print(display_text)
         subprocess.call('printf "{text}" > /dev/ttyS0'.format(text=display_text), shell=True)
         sleep(60)
 finally:

--- a/bart.py
+++ b/bart.py
@@ -46,7 +46,7 @@ def get_predictions(orig='16TH'):
     arrivals = get_bart_times(api_params)
     line_predictions = []
 
-    for destination, minutes in arrivals.iteritems():
+    for destination, minutes in arrivals.items():
         line_predictions.append(format_bart_information(destination, minutes))
 
     bart_text += '<FI>'.join(line_predictions)

--- a/muni.py
+++ b/muni.py
@@ -38,10 +38,10 @@ def format_route_times(route, bus_times, direction = ''):
 def get_predictions():
     muni_predictions = "<CP>MUNI Arrivals<FI>"
     direction_string = "<SA>{routes}<FI>"
-    for station_code, direction in STATION_CODES.iteritems():
+    for station_code, direction in STATION_CODES.items():
         route_predictions = []
         predictions = request_511_xml(station_code)
-        for route, times in predictions.iteritems():
+        for route, times in predictions.items():
             route_predictions.append(format_route_times(route, times, direction))
         muni_predictions += direction_string.format(routes='<FI>'.join(route_predictions))
 


### PR DESCRIPTION
It's 2016, no reason to not have python 3 compatibility!

Conversely, having `venv` come standard is a great reason for it!

Only minor changes needed (mostly calling `items` instead of `iteritems` on dict comprehensions, which sacrifices python 2 performance in favor of python 3 performance)
